### PR TITLE
feat: complete Rails template defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ newapp:
 
 clean:
 	rm -rf blog
+
+test_output: clean newapp
+	ruby test/template_output_test.rb

--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ rails new blog --css tailwind -m https://raw.githubusercontent.com/narralabs/tho
 
 - [Awesome Print](https://github.com/awesome-print/awesome_print) for beautiful puts statements
 - [Devise](https://github.com/heartcombo/devise) for authentication
+- [Immosquare Cookies](https://github.com/immosquare/immosquare-cookies) for GDPR cookie consent
 - [Haml](https://github.com/haml/haml-rails) for beautiful HTML markups
 - [Simple Form](https://github.com/heartcombo/simple_form) for easier forms
 - [SitemapGenerator](https://github.com/kjvarga/sitemap_generator) for generating sitemaps
 - [Sidekiq](https://github.com/sidekiq/sidekiq) for processing background jobs
+- [Mailkick](https://github.com/ankane/mailkick) for subscriptions and one-click email unsubscribe
 - [Rack Timeout](https://github.com/zombocom/rack-timeout) to abort requests that are taking too long
 - [Rubocop](https://github.com/rubocop/rubocop) for static code analysis
 - [High Voltage](https://github.com/thoughtbot/high_voltage) for static pages
 - [Title](https://github.com/calebhearth/title) for storing titles in translations
+- [ViewComponent](https://github.com/ViewComponent/view_component) for reusable, testable view components
 
 ### Testing Gems
 
@@ -47,6 +50,7 @@ rails new blog --css tailwind -m https://raw.githubusercontent.com/narralabs/tho
 - [FactoryBot](https://github.com/thoughtbot/factory_bot_rails) for fixtures
 - [Timecop](https://github.com/travisjeffery/timecop) for time testing
 - [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for one-line matchers
+- [Annotate](https://github.com/ctran/annotate_models) for model schema comments
 
 ### Security Gems
 
@@ -215,3 +219,7 @@ To develop and contribute to the project:
 3. [ADD NEW GEMS OR CONFIG HERE]
 4. Run the makefile which creates the app named "blog" in the current dir: `make`
 5. Check the output logs and inspect the `blog` app to see if the files and config are generated correctly
+6. Run `make test_output` to regenerate the app and verify the template defaults.
+
+Generated applications include Mailcatcher for local email previews. Start it with
+`docker compose up mailcatcher`, then open `http://localhost:1080`.

--- a/template.rb
+++ b/template.rb
@@ -1,5 +1,7 @@
 gem "awesome_print", comment: "Use Awesome Print for better printing"
 gem "devise", comment: "Use Devise for authentication"
+gem "immosquare-cookies", "~> 2.0", comment: "Provide GDPR cookie consent controls"
+gem "mailkick", "~> 1.3.1", comment: "Provide email subscriptions and one-click unsubscribe"
 
 gem "html2haml", comment: "Use HTML2HAML to convert erb to haml"
 gem "haml-rails", "~> 2.0", comment: "Use HAML for HTML templates"
@@ -13,6 +15,7 @@ gem "rack-timeout", comment: "Use Rack Timeout to timeout requests"
 gem "high_voltage", comment: "Use High Voltage for static pages"
 
 gem "title", comment: "Use Title for dynamic page titles"
+gem "view_component", "~> 3.25", comment: "Organize reusable, testable view components"
 
 gem "sidekiq", comment: "Use Sidekiq for background jobs"
 
@@ -23,10 +26,34 @@ gem "asset_sync", comment: "To upload assets to S3 after precompiling assets"
 gem "fog-aws", comment: "To use AWS with asset_sync"
 
 gem_group :development, :test do
+  gem "annotate", "~> 3.2", require: false, comment: "Document database columns in models"
   gem "rspec-rails", '~> 6.1.0', comment: "Use RSpec for testing"
   gem "factory_bot_rails", comment: "Use Factory Bot for fixtures"
   gem "timecop", comment: "Use Timecop for time testing"
 end
+
+create_file ".rubocop.yml", <<~YAML
+  plugins:
+    - rubocop-rails
+
+  Style/StringLiterals:
+    EnforcedStyle: double_quotes
+    SupportedStyles:
+      - single_quotes
+      - double_quotes
+
+  Style/Documentation:
+    Enabled: false
+
+  Style/FrozenStringLiteralComment:
+    Enabled: false
+
+  Style/EmptyMethod:
+    Enabled: false
+
+  Metrics/MethodLength:
+    Max: 20
+YAML
 
 gem_group :test do
   gem 'shoulda-matchers', '~> 6.0', comment: "Use Shoulda Matchers for test matchers"
@@ -42,6 +69,35 @@ CODE
 create_file "app/views/welcome/index.html.haml", <<-CODE
 %h1 Hello World from Thomas
 CODE
+
+create_file "app/helpers/application_helper.rb", <<~RUBY
+  module ApplicationHelper
+    def title_tag
+      content_for(:title).presence || Rails.application.class.module_parent_name.titleize
+    end
+  end
+RUBY
+
+create_file "app/components/application_component.rb", <<~RUBY
+  class ApplicationComponent < ViewComponent::Base
+  end
+RUBY
+
+create_file "compose.yml", <<~YAML
+  services:
+    mailcatcher:
+      image: sj26/mailcatcher:latest
+      ports:
+        - "1025:1025"
+        - "1080:1080"
+YAML
+
+environment <<~RUBY, env: "development"
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: "127.0.0.1", port: 1025 }
+  config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")
+RUBY
 
 after_bundle do
   # Convert existing erb files to haml
@@ -68,11 +124,88 @@ after_bundle do
 CODE
 
   insert_into_file "app/views/layouts/application.html.haml", after: "  %body\n" do
-    "    = render 'shared/flash'\n"
+    "    = render \"shared/flash\"\n    = render \"immosquare-cookies/consent_banner\"\n"
   end
+
+  gsub_file "app/views/layouts/application.html.haml", /^\s*%title.*$/, "    %title= title_tag"
 
   # Run the simple_form generator
   run "rails generate simple_form:install"
+
+  # Install application authentication and a protected admin dashboard.
+  run "rails generate devise:install"
+  run "rails generate devise Admin"
+  run "rails generate mailkick:install"
+  run "rails generate annotate:install"
+
+  route <<~RUBY
+    namespace :admin do
+      root "dashboard#index"
+    end
+  RUBY
+
+  create_file "app/controllers/admin/base_controller.rb", <<~RUBY
+    class Admin::BaseController < ApplicationController
+      before_action :authenticate_admin!
+
+      layout "admin"
+    end
+  RUBY
+
+  create_file "app/controllers/admin/dashboard_controller.rb", <<~RUBY
+    class Admin::DashboardController < Admin::BaseController
+      def index
+      end
+    end
+  RUBY
+
+  create_file "app/views/layouts/admin.html.haml", <<~HAML
+    !!!
+    %html
+      %head
+        %title= title_tag
+        %meta{name: "viewport", content: "width=device-width,initial-scale=1"}
+        = csrf_meta_tags
+        = csp_meta_tag
+      %body
+        %header
+          %nav
+            = link_to "Dashboard", admin_root_path
+            = button_to "Sign out", destroy_admin_session_path, method: :delete
+        %main= yield
+  HAML
+
+  create_file "app/views/admin/dashboard/index.html.haml", <<~HAML
+    - content_for :title, "Admin dashboard"
+    %h1 Admin dashboard
+    %p Use this protected area for application administration.
+  HAML
+
+  create_file "config/initializers/mailkick.rb", <<~RUBY
+    # Add RFC 8058 one-click unsubscribe headers to Mailkick-enabled emails.
+    Mailkick.headers = true
+  RUBY
+
+  remove_file "app/views/layouts/mailer.html.erb"
+  remove_file "app/views/layouts/mailer.text.erb"
+  remove_file "app/views/layouts/mailer.html.haml"
+  remove_file "app/views/layouts/mailer.text.haml"
+  create_file "app/views/layouts/mailer.html.haml", <<~HAML
+    !!!
+    %html
+      %head
+        %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}
+      %body{style: "background:#f6f7f9;margin:0;padding:32px 16px;font-family:Arial,sans-serif;color:#17202a"}
+        %table{role: "presentation", width: "100%", cellspacing: "0", cellpadding: "0"}
+          %tr
+            %td{align: "center"}
+              %table{role: "presentation", width: "600", cellspacing: "0", cellpadding: "32", style: "max-width:600px;width:100%;background:#fff;border-radius:8px"}
+                %tr
+                  %td= yield
+  HAML
+  create_file "app/views/layouts/mailer.text.haml", <<~HAML
+    = yield
+  HAML
 
   # Run the rspec generator and remove the test directory
   run "rails generate rspec:install"
@@ -107,6 +240,28 @@ STR
 Rack::Timeout::Logger.disable
 CODE
 
+  # Keep load-balancer probes available without flooding production logs.
+  route 'get "/up", to: proc { [200, { "Content-Type" => "text/plain" }, ["OK"]] }'
+  create_file "app/middleware/healthcheck_silencer.rb", <<~RUBY
+    class HealthcheckSilencer
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        return @app.call(env) unless env["PATH_INFO"] == "/up"
+
+        Rails.logger.silence { @app.call(env) }
+      end
+    end
+  RUBY
+  insert_into_file "config/application.rb", after: "require_relative \"boot\"\n" do
+    "require_relative \"../app/middleware/healthcheck_silencer\"\n"
+  end
+  insert_into_file "config/application.rb", after: "class Application < Rails::Application\n" do
+    "    config.middleware.insert_before Rails::Rack::Logger, HealthcheckSilencer\n"
+  end
+
   git add: "."
-  git commit: %Q{ -m 'Initial commit' }
+  git commit: %Q{ -m 'chore: initialize Rails application' }
 end

--- a/test/template_output_test.rb
+++ b/test/template_output_test.rb
@@ -1,0 +1,46 @@
+require "minitest/autorun"
+
+class TemplateOutputTest < Minitest::Test
+  ROOT = File.expand_path("../blog", __dir__)
+
+  def test_expected_gems
+    gemfile = read("Gemfile")
+
+    %w[annotate devise immosquare-cookies mailkick view_component].each do |gem_name|
+      assert_includes gemfile, "gem \"#{gem_name}\""
+    end
+  end
+
+  def test_welcome_page
+    assert_file "app/controllers/welcome_controller.rb"
+    assert_file "app/views/welcome/index.html.haml"
+  end
+
+  def test_application_defaults
+    assert_includes read("app/views/layouts/application.html.haml"), "%title= title_tag"
+    assert_file "app/views/layouts/mailer.html.haml"
+    assert_file "app/components/application_component.rb"
+    assert_file ".rubocop.yml"
+  end
+
+  def test_admin_dashboard
+    assert_file "app/models/admin.rb"
+    assert_file "app/controllers/admin/dashboard_controller.rb"
+    assert_file "app/views/admin/dashboard/index.html.haml"
+  end
+
+  def test_production_healthcheck_silencing
+    assert_file "app/middleware/healthcheck_silencer.rb"
+    assert_includes read("config/routes.rb"), 'get "/up"'
+  end
+
+  private
+
+  def assert_file(relative_path)
+    assert File.file?(File.join(ROOT, relative_path)), "Expected #{relative_path} to exist"
+  end
+
+  def read(relative_path)
+    File.read(File.join(ROOT, relative_path))
+  end
+end


### PR DESCRIPTION
## Summary
- add title, mailer, healthcheck, RuboCop, and output-test defaults
- add Devise-backed admin dashboard, ViewComponent, and model annotation support
- add Mailkick unsubscribe support, GDPR cookie consent, and Mailcatcher development setup

## Verification
- `make test_output` (5 runs, 23 assertions)
- generated app database migrations and route loading
- generated app middleware boot check
- generated app RSpec suite (0 failures)

Closes #4
Closes #5
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16