### PR TITLE
test: verify generated application output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ newapp:
 
 clean:
 	rm -rf blog
+
+test_output: clean newapp
+	ruby test/template_output_test.rb

--- a/template.rb
+++ b/template.rb
@@ -89,7 +89,7 @@ end
 STR
 
   # Add sidekiq production config
-  gsub_file "config/environments/production.rb", /# config.active_job.queue_adapter = :resque/, "config.active_job.queue_adapter = :sidekiq"
+  gsub_file "config/environments/production.rb", /# config\.active_job\.queue_adapter\s+=\s+:resque/, "config.active_job.queue_adapter = :sidekiq"
 
   #run "bundle exec rails generate devise:install"
   #run "bundle exec generate devise User"

--- a/test/template_output_test.rb
+++ b/test/template_output_test.rb
@@ -1,0 +1,35 @@
+require "minitest/autorun"
+
+class TemplateOutputTest < Minitest::Test
+  ROOT = File.expand_path("../blog", __dir__)
+
+  def test_expected_gems
+    gemfile = read("Gemfile")
+
+    %w[haml-rails rspec-rails simple_form].each do |gem_name|
+      assert_includes gemfile, "gem \"#{gem_name}\""
+    end
+  end
+
+  def test_welcome_page
+    assert_file "app/controllers/welcome_controller.rb"
+    assert_file "app/views/welcome/index.html.haml"
+  end
+
+  def test_production_defaults
+    production = read("config/environments/production.rb")
+
+    assert_includes production, "config.active_job.queue_adapter = :sidekiq"
+    assert_file "config/initializers/rack_timeout.rb"
+  end
+
+  private
+
+  def assert_file(relative_path)
+    assert File.file?(File.join(ROOT, relative_path)), "Expected #{relative_path} to exist"
+  end
+
+  def read(relative_path)
+    File.read(File.join(ROOT, relative_path))
+  end
+end


### PR DESCRIPTION
Adds a focused generated-output test target covering Gemfile contents, welcome files, and production defaults.

Closes #4