### PR TITLE
feat: add GDPR cookie consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ rails new blog --css tailwind -m https://raw.githubusercontent.com/narralabs/tho
 
 - [Awesome Print](https://github.com/awesome-print/awesome_print) for beautiful puts statements
 - [Devise](https://github.com/heartcombo/devise) for authentication
+- [Immosquare Cookies](https://github.com/immosquare/immosquare-cookies) for GDPR cookie consent
 - [Haml](https://github.com/haml/haml-rails) for beautiful HTML markups
 - [Simple Form](https://github.com/heartcombo/simple_form) for easier forms
 - [SitemapGenerator](https://github.com/kjvarga/sitemap_generator) for generating sitemaps

--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,7 @@
 gem "awesome_print", comment: "Use Awesome Print for better printing"
 gem "devise", comment: "Use Devise for authentication"
 gem "mailkick", "~> 1.3.1", comment: "Provide email subscriptions and one-click unsubscribe"
+gem "immosquare-cookies", "~> 2.0", comment: "Provide GDPR cookie consent controls"
 
 gem "html2haml", comment: "Use HTML2HAML to convert erb to haml"
 gem "haml-rails", "~> 2.0", comment: "Use HAML for HTML templates"
@@ -92,7 +93,7 @@ after_bundle do
 CODE
 
   insert_into_file "app/views/layouts/application.html.haml", after: "  %body\n" do
-    "    = render 'shared/flash'\n"
+    "    = render 'shared/flash'\n    = render \"immosquare-cookies/consent_banner\"\n"
   end
 
   # Run the simple_form generator


### PR DESCRIPTION
Adds the maintained Immosquare Cookies gem and renders its consent banner from the application layout.

Closes #11