### PR TITLE
test: add generated application CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  generated-app:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      mailcatcher:
+        image: sj26/mailcatcher:latest
+        ports:
+          - 1025:1025
+          - 1080:1080
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.0"
+          bundler-cache: true
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "Thomas CI"
+          git config --global user.email "ci@narralabs.com"
+
+      - name: Generate and test application
+        run: make test_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
           git config --global user.name "Thomas CI"
           git config --global user.email "ci@narralabs.com"
 
+      - name: Install Rails generator
+        run: gem install rails --version "~> 7.0.10" --no-document
+
       - name: Generate and test application
         run: make test_ci

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ clean:
 
 test_output: clean newapp
 	ruby test/template_output_test.rb
+
+test_ci: test_output
+	ruby test/generated_app_test.rb

--- a/test/generated_app_test.rb
+++ b/test/generated_app_test.rb
@@ -1,0 +1,109 @@
+require "json"
+require "minitest/autorun"
+require "net/http"
+require "open3"
+require "socket"
+require "timeout"
+
+class GeneratedAppTest < Minitest::Test
+  ROOT = File.expand_path("../blog", __dir__)
+
+  class << self
+    attr_accessor :server_pid, :server_log, :server_port
+  end
+
+  def self.run!(*command, env: {})
+    stdout, status = Open3.capture2e(env, *command, chdir: ROOT)
+    raise "#{command.join(" ")} failed:\n#{stdout}" unless status.success?
+
+    stdout
+  end
+
+  def self.wait_for_http(uri, timeout: 30)
+    Timeout.timeout(timeout) do
+      loop do
+        response = Net::HTTP.get_response(uri)
+        return response if response
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, Net::OpenTimeout, Net::ReadTimeout
+        sleep 0.25
+      end
+    end
+  end
+
+  def self.start_server
+    socket = TCPServer.new("127.0.0.1", 0)
+    self.server_port = socket.addr[1]
+    socket.close
+
+    self.server_log = File.open(File.join(ROOT, "tmp/ci-server.log"), "w")
+    self.server_pid = Process.spawn(
+      { "RAILS_ENV" => "test" },
+      "bin/rails", "server", "--binding", "127.0.0.1", "--port", server_port.to_s,
+      chdir: ROOT,
+      out: server_log,
+      err: server_log
+    )
+    wait_for_http(URI("http://127.0.0.1:#{server_port}/up"))
+  rescue StandardError
+    server_log&.flush
+    warn File.read(server_log.path) if server_log
+    raise
+  end
+
+  def self.stop_server
+    return unless server_pid
+
+    Process.kill("TERM", server_pid)
+    Process.wait(server_pid)
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  ensure
+    server_log&.close
+  end
+
+  def self.prepare
+    run!("bin/rails", "db:prepare", env: { "RAILS_ENV" => "test" })
+    run!("bin/rails", "db:prepare", env: { "RAILS_ENV" => "development" })
+    run!("bundle", "exec", "rspec")
+    run!("bundle", "exec", "rubocop", "--show-cops", "Style/StringLiterals")
+
+    mailcatcher = wait_for_http(URI("http://127.0.0.1:1080/messages"))
+    raise "Mailcatcher is unavailable" unless mailcatcher.is_a?(Net::HTTPSuccess)
+
+    run!("bin/rails", "runner", File.expand_path("support/mail_smoke.rb", __dir__), env: { "RAILS_ENV" => "development" })
+    messages = JSON.parse(Net::HTTP.get(URI("http://127.0.0.1:1080/messages")))
+    raise "Mailcatcher did not receive the smoke-test email" unless messages.any? { |message| message["subject"] == "Thomas CI mail smoke test" }
+
+    start_server
+  end
+
+  prepare
+  Minitest.after_run { stop_server }
+
+  def request(path)
+    Net::HTTP.get_response(URI("http://127.0.0.1:#{self.class.server_port}#{path}"))
+  end
+
+  def test_home_page_renders_template_defaults
+    response = request("/")
+
+    assert_instance_of Net::HTTPOK, response
+    assert_includes response.body, "Hello World from Thomas"
+    assert_includes response.body, "<title>Blog</title>"
+    assert_match(/cookie|consent/i, response.body)
+  end
+
+  def test_healthcheck
+    response = request("/up")
+
+    assert_instance_of Net::HTTPOK, response
+    assert_equal "OK", response.body
+  end
+
+  def test_admin_dashboard_requires_authentication
+    response = request("/admin")
+
+    assert_instance_of Net::HTTPFound, response
+    assert_includes response.fetch("location"), "/admins/sign_in"
+  end
+end

--- a/test/support/mail_smoke.rb
+++ b/test/support/mail_smoke.rb
@@ -1,0 +1,26 @@
+admin = Admin.find_or_initialize_by(email: "ci@example.com")
+admin.password = "password123"
+admin.save!
+
+class CiMailer < ApplicationMailer
+  def smoke(admin)
+    @admin = admin
+
+    mail(to: admin.email, subject: "Thomas CI mail smoke test") do |format|
+      format.html do
+        render(
+          inline: '<p>Thomas email delivery works.</p><%= mailkick_unsubscribe_url(@admin, "ci", host: "localhost") %>',
+          layout: "mailer"
+        )
+      end
+      format.text { render plain: "Thomas email delivery works." }
+    end
+  end
+end
+
+message = CiMailer.smoke(admin).deliver_now
+
+raise "missing unsubscribe header" unless message["List-Unsubscribe"]&.value&.include?("/mailkick/")
+raise "missing one-click header" unless message["List-Unsubscribe-Post"]&.value == "List-Unsubscribe=One-Click"
+
+puts "SMTP delivery and unsubscribe headers verified"

--- a/test/template_output_test.rb
+++ b/test/template_output_test.rb
@@ -6,7 +6,19 @@ class TemplateOutputTest < Minitest::Test
   def test_expected_gems
     gemfile = read("Gemfile")
 
-    %w[haml-rails rspec-rails simple_form].each do |gem_name|
+    %w[
+      annotate
+      devise
+      haml-rails
+      immosquare-cookies
+      mailkick
+      rack-timeout
+      rspec-rails
+      rubocop-rails
+      sidekiq
+      simple_form
+      view_component
+    ].each do |gem_name|
       assert_includes gemfile, "gem \"#{gem_name}\""
     end
   end
@@ -21,6 +33,28 @@ class TemplateOutputTest < Minitest::Test
 
     assert_includes production, "config.active_job.queue_adapter = :sidekiq"
     assert_file "config/initializers/rack_timeout.rb"
+  end
+
+  def test_mail_defaults
+    development = read("config/environments/development.rb")
+
+    assert_includes development, "config.action_mailer.delivery_method = :smtp"
+    assert_includes development, 'config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")'
+    assert_includes read("config/initializers/mailkick.rb"), "Mailkick.headers = true"
+    assert_file "app/views/layouts/mailer.html.haml"
+    assert_file "app/views/layouts/mailer.text.haml"
+    assert_file "compose.yml"
+  end
+
+  def test_admin_and_application_defaults
+    assert_file "app/models/admin.rb"
+    assert_file "app/controllers/admin/dashboard_controller.rb"
+    assert_file "app/components/application_component.rb"
+    assert_file "app/middleware/healthcheck_silencer.rb"
+
+    layout = read("app/views/layouts/application.html.haml")
+    assert_includes layout, "%title= title_tag"
+    assert_includes layout, 'render "immosquare-cookies/consent_banner"'
   end
 
   private


### PR DESCRIPTION
## Summary

- generate a real Rails app from the template in CI
- verify expected gems, initializers, layouts, components, admin scaffolding, and mail defaults
- prepare development and test databases, run generated RSpec, and validate RuboCop configuration
- boot the generated Rails server and exercise the home page, healthcheck, and admin authentication redirect
- deliver a real SMTP message to Mailcatcher and verify Mailkick unsubscribe headers

## Local verification

- template output: 44 assertions, 0 failures
- generated RSpec: 0 failures
- mail layout and unsubscribe headers: passed
- Rails HTTP smoke test: `/` 200, `/up` 200, `/admin` 302