### PR TITLE
fix: support Rails 8 application generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby-version }}"
-          bundler-cache: true
 
       - name: Configure Git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby-version: "3.3.0"
+            rails-version: "~> 7.0.10"
+          - ruby-version: "4.0.0"
+            rails-version: "~> 8.1.0"
+
     services:
       mailcatcher:
         image: sj26/mailcatcher:latest
@@ -25,7 +34,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3.0"
+          ruby-version: "${{ matrix.ruby-version }}"
           bundler-cache: true
 
       - name: Configure Git identity
@@ -34,7 +43,7 @@ jobs:
           git config --global user.email "ci@narralabs.com"
 
       - name: Install Rails generator
-        run: gem install rails --version "~> 7.0.10" --no-document
+        run: gem install rails --version "${{ matrix.rails-version }}" --no-document
 
       - name: Generate and test application
         run: make test_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,11 @@ jobs:
       - name: Install Rails generator
         run: gem install rails --version "${{ matrix.rails-version }}" --no-document
 
-      - name: Generate and test application
-        run: make test_ci
+      - name: Generate application from template
+        run: make test_output
+
+      - name: Verify generated application bundle
+        run: make test_bundle
+
+      - name: Test generated application
+        run: ruby test/generated_app_test.rb

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ clean:
 test_output: clean newapp
 	ruby test/template_output_test.rb
 
-test_ci: test_output
+test_bundle:
+	ruby test/bundle_install_test.rb
+
+test_ci: test_output test_bundle
 	ruby test/generated_app_test.rb

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ rails new blog --css tailwind -m https://raw.githubusercontent.com/narralabs/tho
 - [FactoryBot](https://github.com/thoughtbot/factory_bot_rails) for fixtures
 - [Timecop](https://github.com/travisjeffery/timecop) for time testing
 - [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for one-line matchers
-- [Annotate](https://github.com/ctran/annotate_models) for model schema comments
+- [AnnotateRb](https://github.com/drwl/annotaterb) for model schema comments
 
 ### Security Gems
 

--- a/template.rb
+++ b/template.rb
@@ -26,7 +26,7 @@ gem "asset_sync", comment: "To upload assets to S3 after precompiling assets"
 gem "fog-aws", comment: "To use AWS with asset_sync"
 
 gem_group :development, :test do
-  gem "annotate", "~> 3.2", require: false, comment: "Document database columns in models"
+  gem "annotaterb", "~> 4.24", require: false, comment: "Document database columns in models"
   gem "rspec-rails", '~> 6.1.0', comment: "Use RSpec for testing"
   gem "factory_bot_rails", comment: "Use Factory Bot for fixtures"
   gem "timecop", comment: "Use Timecop for time testing"
@@ -131,7 +131,7 @@ CODE
 
   # Run the simple_form generator
   run "rails generate simple_form:install"
-  run "rails generate annotate:install"
+  run "rails generate annotate_rb:install"
 
   run "rails generate mailkick:install"
   create_file "config/initializers/mailkick.rb", <<~RUBY
@@ -221,7 +221,7 @@ end
 STR
 
   # Add sidekiq production config
-  gsub_file "config/environments/production.rb", /# config\.active_job\.queue_adapter\s+=\s+:resque/, "config.active_job.queue_adapter = :sidekiq"
+  environment "config.active_job.queue_adapter = :sidekiq", env: "production"
 
   #run "bundle exec rails generate devise:install"
   #run "bundle exec generate devise User"

--- a/template.rb
+++ b/template.rb
@@ -83,7 +83,11 @@ environment <<~RUBY, env: "development"
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { address: "127.0.0.1", port: 1025 }
-  config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")
+  if Rails::VERSION::MAJOR >= 8
+    config.action_mailer.preview_paths = [Rails.root.join("spec/mailers/previews")]
+  else
+    config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")
+  end
 RUBY
 
 create_file "app/components/application_component.rb", <<~RUBY

--- a/test/bundle_install_test.rb
+++ b/test/bundle_install_test.rb
@@ -1,0 +1,12 @@
+require "minitest/autorun"
+require "open3"
+
+class BundleInstallTest < Minitest::Test
+  ROOT = File.expand_path("../blog", __dir__)
+
+  def test_generated_application_bundle_installs
+    output, status = Open3.capture2e("bundle", "install", chdir: ROOT)
+
+    assert status.success?, "bundle install failed for the generated application:\n#{output}"
+  end
+end

--- a/test/template_output_test.rb
+++ b/test/template_output_test.rb
@@ -7,7 +7,7 @@ class TemplateOutputTest < Minitest::Test
     gemfile = read("Gemfile")
 
     %w[
-      annotate
+      annotaterb
       devise
       haml-rails
       immosquare-cookies

--- a/test/template_output_test.rb
+++ b/test/template_output_test.rb
@@ -39,6 +39,7 @@ class TemplateOutputTest < Minitest::Test
     development = read("config/environments/development.rb")
 
     assert_includes development, "config.action_mailer.delivery_method = :smtp"
+    assert_includes development, 'config.action_mailer.preview_paths = [Rails.root.join("spec/mailers/previews")]'
     assert_includes development, 'config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")'
     assert_includes read("config/initializers/mailkick.rb"), "Mailkick.headers = true"
     assert_file "app/views/layouts/mailer.html.haml"


### PR DESCRIPTION
## Summary

- replace the abandoned `annotate` gem, which rejects Active Record 8, with the maintained `annotaterb` successor
- use the compatible `annotate_rb:install` generator
- configure Sidekiq without depending on Rails 7 generated comments
- test generated applications on both Rails 7/Ruby 3.3 and Rails 8.1/Ruby 4.0

## Root cause

Running the remote template with Rails 8.1 added `annotate ~> 3.2`, whose dependency requires Active Record `< 8.0`. Bundler failed, and all later generators consequently failed because the bundle was incomplete.

## Verification

- Rails 7.0 generated app: 44 assertions, 0 failures
- Rails 8.1 generated app: 44 assertions, 0 failures
- Rails 8.1 database preparation: passed
- Rails 8.1 RSpec and RuboCop loading: passed
- Rails 8.1 mail layout and unsubscribe headers: passed